### PR TITLE
Make sure the package installs without reference to namespaces

### DIFF
--- a/force-app/main/default/flows/Contact_After_Create_Update_Set_Public_Id.flow-meta.xml
+++ b/force-app/main/default/flows/Contact_After_Create_Update_Set_Public_Id.flow-meta.xml
@@ -19,7 +19,7 @@
         </inputParameters>
         <nameSegment>GenerateRandomString</nameSegment>
         <outputParameters>
-            <assignToReference>$Record.UnsubscribeLnk__Public_Id__c</assignToReference>
+            <assignToReference>$Record.Public_Id__c</assignToReference>
             <name>out</name>
         </outputParameters>
         <versionSegment>1</versionSegment>

--- a/force-app/main/default/flows/Lead_After_Create_Update_Set_Public_Id.flow-meta.xml
+++ b/force-app/main/default/flows/Lead_After_Create_Update_Set_Public_Id.flow-meta.xml
@@ -19,7 +19,7 @@
         </inputParameters>
         <nameSegment>GenerateRandomString</nameSegment>
         <outputParameters>
-            <assignToReference>$Record.UnsubscribeLnk__Public_Id__c</assignToReference>
+            <assignToReference>$Record.Public_Id__c</assignToReference>
             <name>out</name>
         </outputParameters>
         <versionSegment>1</versionSegment>


### PR DESCRIPTION
The two lines changed in the set public id flows removes references to the namespace, which breaks these flows when we attempt to deploy the whole thing from VS code.



# Critical Changes

# Changes

# Issues Closed
