### PR TITLE
Update Setup Flow to Limit Types of OrgWide Email

### DIFF
--- a/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
+++ b/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
@@ -284,12 +284,26 @@
         <name>orgWideEmails</name>
         <dataType>String</dataType>
         <displayField>DisplayName</displayField>
-        <filterLogic>and</filterLogic>
+              <filterLogic>1 AND (2 OR 3)</filterLogic>
         <filters>
             <field>IsVerified</field>
             <operator>EqualTo</operator>
             <value>
                 <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Purpose</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>DefaultNoreply</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Purpose</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>UserSelectionAndDefaultNoReply</stringValue>
             </value>
         </filters>
         <object>OrgWideEmailAddress</object>


### PR DESCRIPTION
Limit org wide email to Purpose of DefaultNoReply and UserSelection and default no reply



# Critical Changes

# Changes

# Issues Closed
#51 