### PR TITLE
Update UUIDBatchJob to populate UnsubscribeLink fields

### DIFF
--- a/force-app/main/default/classes/UUIDBatchJob.cls
+++ b/force-app/main/default/classes/UUIDBatchJob.cls
@@ -50,7 +50,7 @@ public class UUIDBatchJob implements Database.Batchable<SObject> {
         // Determine the unsubscribe link field based on object type
         if (objectType.equalsIgnoreCase('Contact')) {
             this.unsubscribeLinkField = 'UnsubscribeLinkContact__c';  // Adjust field name as needed
-        } else if (objectType.equalsIgnoreCase('Lead))')) {
+        } else if (objectType.equalsIgnoreCase('Lead')) {
             this.unsubscribeLinkField = 'UnsubscribeLinkLead__c';
         } else {
             throw new UUIDBatchException('Object type must be Contact or Lead');

--- a/force-app/main/default/classes/UUIDBatchJob.cls
+++ b/force-app/main/default/classes/UUIDBatchJob.cls
@@ -27,100 +27,134 @@ public class UUIDBatchJob implements Database.Batchable<SObject> {
 */
 
 public class UUIDBatchJob implements Database.Batchable<SObject> {
-    private String objectType;
-    private String fieldName;
-    private String unsubscribeLinkField;
-    private String siteBaseUrl;
-    private static final String SITE_NAME = 'Unsubscribe';
-    
-    public UUIDBatchJob(String objectType, String fieldName) {
-        this.objectType = objectType;
-        this.fieldName = fieldName;
-        
-        // Get the base URL for the experience site
-        String partnerURL = URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/u/58.0';
-        Integer servicesIndex = partnerURL.indexOf('/services');
-        if (servicesIndex != -1) {
-            String baseURL = partnerURL.substring(0, servicesIndex + 1);
-            this.siteBaseUrl = baseURL.replace('salesforce.com/', 'site.com/' + SITE_NAME + '/s/');
-        } else {
-            throw new UUIDBatchException('Unable to determine site URL');
+  private String objectType;
+  private String fieldName;
+  private String unsubscribeLinkField;
+  private String siteBaseUrl;
+  private static final String SITE_NAME = 'Unsubscribe';
+  private String objectTypeLetter;
+
+  public UUIDBatchJob(String objectType, String fieldName) {
+    this.objectType = objectType;
+    this.fieldName = fieldName;
+
+    // Get the base URL for the experience site
+    String partnerURL =
+      URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/u/58.0';
+    Integer servicesIndex = partnerURL.indexOf('/services');
+    if (servicesIndex != -1) {
+      String baseURL = partnerURL.substring(0, servicesIndex + 1);
+      this.siteBaseUrl = baseURL.replace(
+        'salesforce.com/',
+        'site.com/' + SITE_NAME + '/s/'
+      );
+    } else {
+      throw new UUIDBatchException('Unable to determine site URL');
+    }
+
+    // Determine the unsubscribe link field based on object type
+    if (objectType.equalsIgnoreCase('Contact')) {
+      this.unsubscribeLinkField = 'UnsubscribeLinkContact__c'; // Adjust field name as needed
+      this.objectTypeLetter = 'C';
+    } else if (objectType.equalsIgnoreCase('Lead')) {
+      this.unsubscribeLinkField = 'UnsubscribeLinkLead__c';
+      this.objectTypeLetter = 'L';
+    } else {
+      throw new UUIDBatchException('Object type must be Contact or Lead');
+    }
+  }
+
+  public Database.QueryLocator start(Database.BatchableContext bc) {
+    // Get records with null UUID field, include UnsubscribeLink field
+    String query =
+      'SELECT Id, ' +
+      fieldName +
+      ', ' +
+      unsubscribeLinkField +
+      ' FROM ' +
+      objectType +
+      ' WHERE ' +
+      fieldName +
+      ' = null';
+    return Database.getQueryLocator(query);
+  }
+
+  public void execute(Database.BatchableContext bc, List<SObject> scope) {
+    try {
+      // Generate UUIDs for records
+      UUIDUtility.generateUUIDsForRecords(scope, fieldName);
+
+      // Generate unsubscribe links using the newly created UUIDs
+      for (SObject record : scope) {
+        String uuid = (String) record.get(fieldName);
+        if (uuid != null) {
+          String unsubscribeLink = generateUnsubscribeLink(uuid);
+          record.put(unsubscribeLinkField, unsubscribeLink);
         }
-        
-        // Determine the unsubscribe link field based on object type
-        if (objectType.equalsIgnoreCase('Contact')) {
-            this.unsubscribeLinkField = 'UnsubscribeLinkContact__c';  // Adjust field name as needed
-        } else if (objectType.equalsIgnoreCase('Lead')) {
-            this.unsubscribeLinkField = 'UnsubscribeLinkLead__c';
-        } else {
-            throw new UUIDBatchException('Object type must be Contact or Lead');
-        }
+      }
+
+      update scope;
+    } catch (Exception e) {
+      // Log error and send notification
+      System.debug(
+        LoggingLevel.ERROR,
+        'Error in UUIDBatchJob: ' + e.getMessage()
+      );
+      throw new UUIDBatchException(
+        'Error processing records: ' + e.getMessage()
+      );
     }
-    
-    public Database.QueryLocator start(Database.BatchableContext bc) {
-        // Get records with null UUID field, include UnsubscribeLink field
-        String query = 'SELECT Id, ' + fieldName + ', ' + unsubscribeLinkField + 
-                      ' FROM ' + objectType + 
-                      ' WHERE ' + fieldName + ' = null';
-        return Database.getQueryLocator(query);
+  }
+
+  public void finish(Database.BatchableContext bc) {
+    // Get the job details
+    AsyncApexJob job = [
+      SELECT
+        Id,
+        Status,
+        NumberOfErrors,
+        JobItemsProcessed,
+        TotalJobItems,
+        CreatedBy.Email
+      FROM AsyncApexJob
+      WHERE Id = :bc.getJobId()
+    ];
+
+    // Send email notification
+    String emailBody = String.format(
+      'The UUID and Unsubscribe Link generation job for ' +
+        objectType +
+        's has completed.\n\n' +
+        'Status: {0}\n' +
+        'Records Processed: {1}\n' +
+        'Number of Errors: {2}',
+      new List<String>{
+        job.Status,
+        String.valueOf(job.JobItemsProcessed),
+        String.valueOf(job.NumberOfErrors)
+      }
+    );
+
+    Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
+    mail.setToAddresses(new List<String>{ job.CreatedBy.Email });
+    mail.setSubject('UUID Batch Job Complete');
+    mail.setPlainTextBody(emailBody);
+
+    try {
+      Messaging.sendEmail(new List<Messaging.SingleEmailMessage>{ mail });
+    } catch (Exception e) {
+      System.debug(
+        LoggingLevel.ERROR,
+        'Error sending completion email: ' + e.getMessage()
+      );
     }
-    
-    public void execute(Database.BatchableContext bc, List<SObject> scope) {
-        try {
-            // Generate UUIDs for records
-            UUIDUtility.generateUUIDsForRecords(scope, fieldName);
-            
-            // Generate unsubscribe links using the newly created UUIDs
-            for (SObject record : scope) {
-                String uuid = (String)record.get(fieldName);
-                if (uuid != null) {
-                    String unsubscribeLink = generateUnsubscribeLink(uuid);
-                    record.put(unsubscribeLinkField, unsubscribeLink);
-                }
-            }
-            
-            update scope;
-            
-        } catch (Exception e) {
-            // Log error and send notification
-            System.debug(LoggingLevel.ERROR, 'Error in UUIDBatchJob: ' + e.getMessage());
-            throw new UUIDBatchException('Error processing records: ' + e.getMessage());
-        }
-    }
-    
-    public void finish(Database.BatchableContext bc) {
-        // Get the job details
-        AsyncApexJob job = [SELECT Id, Status, NumberOfErrors, JobItemsProcessed, 
-                           TotalJobItems, CreatedBy.Email
-                           FROM AsyncApexJob 
-                           WHERE Id = :bc.getJobId()];
-        
-        // Send email notification
-        String emailBody = String.format('The UUID and Unsubscribe Link generation job for ' + objectType + 's has completed.\n\n' +
-                                       'Status: {0}\n' +
-                                       'Records Processed: {1}\n' +
-                                       'Number of Errors: {2}',
-                                       new String[]{
-                                           job.Status,
-                                           String.valueOf(job.JobItemsProcessed),
-                                           String.valueOf(job.NumberOfErrors)
-                                       });
-        
-        Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
-        mail.setToAddresses(new String[]{job.CreatedBy.Email});
-        mail.setSubject('UUID Batch Job Complete');
-        mail.setPlainTextBody(emailBody);
-        
-        try {
-            Messaging.sendEmail(new Messaging.SingleEmailMessage[]{mail});
-        } catch (Exception e) {
-            System.debug(LoggingLevel.ERROR, 'Error sending completion email: ' + e.getMessage());
-        }
-    }
-    
-    private String generateUnsubscribeLink(String uuid) {
-        return siteBaseUrl + 'unsubscribe?varRecId=' + uuid;
-    }
-    
-    public class UUIDBatchException extends Exception {}
+  }
+
+  private String generateUnsubscribeLink(String uuid) {
+    System.debug(objectTypeLetter + ' object type letter');
+    return siteBaseUrl + 'unsubscribe?varRecId=' + objectTypeLetter + uuid;
+  }
+
+  public class UUIDBatchException extends Exception {
+  }
 }

--- a/force-app/main/default/classes/UUIDBatchJob.cls
+++ b/force-app/main/default/classes/UUIDBatchJob.cls
@@ -1,3 +1,4 @@
+/*
 public class UUIDBatchJob implements Database.Batchable<SObject> {
     private String objectType;
     private String fieldName;
@@ -22,4 +23,104 @@ public class UUIDBatchJob implements Database.Batchable<SObject> {
     public void finish(Database.BatchableContext bc) {
         // TO DO: Send email notification when batch completes
     }
+}
+*/
+
+public class UUIDBatchJob implements Database.Batchable<SObject> {
+    private String objectType;
+    private String fieldName;
+    private String unsubscribeLinkField;
+    private String siteBaseUrl;
+    private static final String SITE_NAME = 'Unsubscribe';
+    
+    public UUIDBatchJob(String objectType, String fieldName) {
+        this.objectType = objectType;
+        this.fieldName = fieldName;
+        
+        // Get the base URL for the experience site
+        String partnerURL = URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/u/58.0';
+        Integer servicesIndex = partnerURL.indexOf('/services');
+        if (servicesIndex != -1) {
+            String baseURL = partnerURL.substring(0, servicesIndex + 1);
+            this.siteBaseUrl = baseURL.replace('salesforce.com/', 'site.com/' + SITE_NAME + '/s/');
+        } else {
+            throw new UUIDBatchException('Unable to determine site URL');
+        }
+        
+        // Determine the unsubscribe link field based on object type
+        if (objectType.equalsIgnoreCase('Contact')) {
+            this.unsubscribeLinkField = 'UnsubscribeLinkContact__c';  // Adjust field name as needed
+        } else if (objectType.equalsIgnoreCase('Lead))')) {
+            this.unsubscribeLinkField = 'UnsubscribeLinkLead__c';
+        } else {
+            throw new UUIDBatchException('Object type must be Contact or Lead');
+        }
+    }
+    
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        // Get records with null UUID field, include UnsubscribeLink field
+        String query = 'SELECT Id, ' + fieldName + ', ' + unsubscribeLinkField + 
+                      ' FROM ' + objectType + 
+                      ' WHERE ' + fieldName + ' = null';
+        return Database.getQueryLocator(query);
+    }
+    
+    public void execute(Database.BatchableContext bc, List<SObject> scope) {
+        try {
+            // Generate UUIDs for records
+            UUIDUtility.generateUUIDsForRecords(scope, fieldName);
+            
+            // Generate unsubscribe links using the newly created UUIDs
+            for (SObject record : scope) {
+                String uuid = (String)record.get(fieldName);
+                if (uuid != null) {
+                    String unsubscribeLink = generateUnsubscribeLink(uuid);
+                    record.put(unsubscribeLinkField, unsubscribeLink);
+                }
+            }
+            
+            update scope;
+            
+        } catch (Exception e) {
+            // Log error and send notification
+            System.debug(LoggingLevel.ERROR, 'Error in UUIDBatchJob: ' + e.getMessage());
+            throw new UUIDBatchException('Error processing records: ' + e.getMessage());
+        }
+    }
+    
+    public void finish(Database.BatchableContext bc) {
+        // Get the job details
+        AsyncApexJob job = [SELECT Id, Status, NumberOfErrors, JobItemsProcessed, 
+                           TotalJobItems, CreatedBy.Email
+                           FROM AsyncApexJob 
+                           WHERE Id = :bc.getJobId()];
+        
+        // Send email notification
+        String emailBody = String.format('The UUID and Unsubscribe Link generation job for ' + objectType + 's has completed.\n\n' +
+                                       'Status: {0}\n' +
+                                       'Records Processed: {1}\n' +
+                                       'Number of Errors: {2}',
+                                       new String[]{
+                                           job.Status,
+                                           String.valueOf(job.JobItemsProcessed),
+                                           String.valueOf(job.NumberOfErrors)
+                                       });
+        
+        Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
+        mail.setToAddresses(new String[]{job.CreatedBy.Email});
+        mail.setSubject('UUID Batch Job Complete');
+        mail.setPlainTextBody(emailBody);
+        
+        try {
+            Messaging.sendEmail(new Messaging.SingleEmailMessage[]{mail});
+        } catch (Exception e) {
+            System.debug(LoggingLevel.ERROR, 'Error sending completion email: ' + e.getMessage());
+        }
+    }
+    
+    private String generateUnsubscribeLink(String uuid) {
+        return siteBaseUrl + 'unsubscribe?varRecId=' + uuid;
+    }
+    
+    public class UUIDBatchException extends Exception {}
 }

--- a/force-app/main/default/classes/UUIDBatchJobTest.cls
+++ b/force-app/main/default/classes/UUIDBatchJobTest.cls
@@ -35,7 +35,7 @@ private class UUIDBatchJobTest {
         // Act: Run the batch job for Contacts
         UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
         Test.startTest();
-        Database.executeBatch(batchJob, 200); // Simulate multiple batches
+        Database.executeBatch(batchJob, 200);
         Test.stopTest();
 
         // Assert: Check that all Contacts now have a generated UUID

--- a/force-app/main/default/classes/UUIDBatchJobTest.cls
+++ b/force-app/main/default/classes/UUIDBatchJobTest.cls
@@ -1,101 +1,201 @@
 @isTest
 private class UUIDBatchJobTest {
+  @TestSetup
+  static void setupTestData() {
+    // Arrange: Create test data for Contacts and Leads with null UUID fields
+    List<Contact> contacts = new List<Contact>();
+    List<Lead> leads = new List<Lead>();
 
-    @TestSetup
-    static void setupTestData() {
-        // Arrange: Create test data for Contacts and Leads with null UUID fields
-        List<Contact> contacts = new List<Contact>();
-        List<Lead> leads = new List<Lead>();
-
-        for (Integer i = 0; i < 200; i++) {
-            contacts.add(new Contact(
-                FirstName = 'Test',
-                LastName = 'McTester ' + i,
-                Public_Id__c = null // Field to hold the UUID
-            ));
-            leads.add(new Lead(
-                FirstName = 'Test',
-                LastName = 'McLeader ' + i,
-                Company = 'Test Company',
-                Public_Id__c = null // Field to hold the UUID
-            ));
-        }
-
-        // Insert test records
-        insert contacts;
-        insert leads;
+    for (Integer i = 0; i < 200; i++) {
+      contacts.add(
+        new Contact(
+          FirstName = 'Test',
+          LastName = 'McTester ' + i,
+          Public_Id__c = null // Field to hold the UUID
+        )
+      );
+      leads.add(
+        new Lead(
+          FirstName = 'Test',
+          LastName = 'McLeader ' + i,
+          Company = 'Test Company',
+          Public_Id__c = null // Field to hold the UUID
+        )
+      );
     }
 
-    @isTest
-    static void testBatchJobForContacts() {
-        // Arrange
-        List<Contact> contactsBefore = [SELECT Id, Public_Id__c FROM Contact WHERE Public_Id__c = null];
-        System.assertEquals(200, contactsBefore.size(), 'Should have 200 contacts with null UUIDs before the batch job.');
+    // Insert test records
+    insert contacts;
+    insert leads;
+  }
 
-        // Act: Run the batch job for Contacts
-        UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
-        Test.startTest();
-        Database.executeBatch(batchJob, 200);
-        Test.stopTest();
+  @isTest
+  static void testBatchJobForContacts() {
+    // Arrange
+    List<Contact> contactsBefore = [
+      SELECT Id, Public_Id__c
+      FROM Contact
+      WHERE Public_Id__c = NULL
+    ];
+    System.assertEquals(
+      200,
+      contactsBefore.size(),
+      'Should have 200 contacts with null UUIDs before the batch job.'
+    );
 
-        // Assert: Check that all Contacts now have a generated UUID
-        List<Contact> contactsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkContact__c FROM Contact WHERE Public_Id__c != null];
-        System.assertEquals(200, contactsAfter.size(), 'All contacts should have a generated UUID after the batch job.');
-        for (Contact c : contactsAfter) {
-            System.assertNotEquals(null, c.Public_Id__c, 'Public_Id__c should not be null after the batch job.');
-            System.assertEquals(36, c.Public_Id__c.length(), 'Public_Id__c should be a valid UUID of 36 characters.');
-            System.assertNotEquals(null, c.UnsubscribeLinkContact__c, 'Unsubscribe link should be generated.');
-        }
+    // Act: Run the batch job for Contacts
+    UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
+    Test.startTest();
+    Database.executeBatch(batchJob, 200);
+    Test.stopTest();
+
+    // Assert: Check that all Contacts now have a generated UUID
+    List<Contact> contactsAfter = [
+      SELECT Id, Public_Id__c, UnsubscribeLinkContact__c
+      FROM Contact
+      WHERE Public_Id__c != NULL
+    ];
+
+    System.assertEquals(
+      200,
+      contactsAfter.size(),
+      'All contacts should have a generated UUID after the batch job.'
+    );
+    for (Contact c : contactsAfter) {
+      System.assertNotEquals(
+        null,
+        c.Public_Id__c,
+        'Public_Id__c should not be null after the batch job.'
+      );
+      System.assertEquals(
+        36,
+        c.Public_Id__c.length(),
+        'Public_Id__c should be a valid UUID of 36 characters.'
+      );
+      System.assertNotEquals(
+        null,
+        c.UnsubscribeLinkContact__c,
+        'Unsubscribe link should be generated.'
+      );
     }
+  }
 
-    @isTest
-    static void testBatchJobForLeads() {
-        // Arrange
-        List<Lead> leadsBefore = [SELECT Id, Public_Id__c FROM Lead WHERE Public_Id__c = null];
-        System.assertEquals(200, leadsBefore.size(), 'Should have 200 leads with null UUIDs before the batch job.');
+  @isTest
+  static void testBatchJobForLeads() {
+    // Arrange
+    List<Lead> leadsBefore = [
+      SELECT Id, Public_Id__c
+      FROM Lead
+      WHERE Public_Id__c = NULL
+    ];
+    System.assertEquals(
+      200,
+      leadsBefore.size(),
+      'Should have 200 leads with null UUIDs before the batch job.'
+    );
 
-        // Act: Run the batch job for Leads
-        UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
-        Test.startTest();
-        Database.executeBatch(batchJob, 200);
-        Test.stopTest();
+    // Act: Run the batch job for Leads
+    UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
+    Test.startTest();
+    Database.executeBatch(batchJob, 200);
+    Test.stopTest();
 
-        // Assert: Check that all Leads now have a generated UUID
-        List<Lead> leadsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkLead__c FROM Lead WHERE Public_Id__c != null];
-        System.assertEquals(200, leadsAfter.size(), 'All leads should have a generated UUID after the batch job.');
-        for (Lead l : leadsAfter) {
-            System.assertNotEquals(null, l.Public_Id__c, 'Public_Id__c should not be null after the batch job.');
-            System.assertEquals(36, l.Public_Id__c.length(), 'Public_Id__c should be a valid UUID of 36 characters.');
-            System.assertNotEquals(null, l.UnsubscribeLinkLead__c, 'Unsubscribe link should be generated.');
-        }
+    // Assert: Check that all Leads now have a generated UUID
+    List<Lead> leadsAfter = [
+      SELECT Id, Public_Id__c, UnsubscribeLinkLead__c
+      FROM Lead
+      WHERE Public_Id__c != NULL
+    ];
+    System.assertEquals(
+      200,
+      leadsAfter.size(),
+      'All leads should have a generated UUID after the batch job.'
+    );
+    for (Lead l : leadsAfter) {
+      System.assertNotEquals(
+        null,
+        l.Public_Id__c,
+        'Public_Id__c should not be null after the batch job.'
+      );
+      System.assertEquals(
+        36,
+        l.Public_Id__c.length(),
+        'Public_Id__c should be a valid UUID of 36 characters.'
+      );
+      System.assertNotEquals(
+        null,
+        l.UnsubscribeLinkLead__c,
+        'Unsubscribe link should be generated.'
+      );
     }
+  }
 
-    // Test the error handling when an invalid object type is passed
-    @isTest
-    static void testInvalidObjectType() {
-        Test.startTest();
-        try {
-            UUIDBatchJob invalidBatchJob = new UUIDBatchJob('InvalidObject', 'Public_Id__c');
-            Database.executeBatch(invalidBatchJob, 200);
-            System.assert(false, 'An exception should have been thrown for invalid object type.');
-        } catch (UUIDBatchJob.UUIDBatchException e) {
-            System.assertEquals('Object type must be Contact or Lead', e.getMessage());
-        }
-        Test.stopTest();
+  // Test the error handling when an invalid object type is passed
+  @isTest
+  static void testInvalidObjectType() {
+    Test.startTest();
+    try {
+      UUIDBatchJob invalidBatchJob = new UUIDBatchJob(
+        'InvalidObject',
+        'Public_Id__c'
+      );
+      Database.executeBatch(invalidBatchJob, 200);
+      System.assert(
+        false,
+        'An exception should have been thrown for invalid object type.'
+      );
+    } catch (UUIDBatchJob.UUIDBatchException e) {
+      System.assertEquals(
+        'Object type must be Contact or Lead',
+        e.getMessage()
+      );
     }
+    Test.stopTest();
+  }
 
-    @isTest
-    static void testUnsubscribeLinkGeneration() {
-        // Arrange: Run the batch job and check unsubscribe link generation
-        UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
-        Test.startTest();
-        Database.executeBatch(batchJob, 200);
-        Test.stopTest();
+  @isTest
+  static void testUnsubscribeLinkGeneration() {
+    // Arrange: Run the batch job and check unsubscribe link generation
+    UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
+    Test.startTest();
+    Database.executeBatch(batchJob, 200);
+    Test.stopTest();
 
-        // Assert: Verify unsubscribe links are generated for all contacts
-        List<Contact> contactsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkContact__c FROM Contact WHERE Public_Id__c != null];
-        for (Contact c : contactsAfter) {
-            System.assertNotEquals(null, c.UnsubscribeLinkContact__c, 'Unsubscribe link should not be null after batch execution.');
-        }
+    // Assert: Verify unsubscribe links are generated for all contacts
+    List<Contact> contactsAfter = [
+      SELECT Id, Public_Id__c, UnsubscribeLinkContact__c
+      FROM Contact
+      WHERE Public_Id__c != NULL
+    ];
+    for (Contact c : contactsAfter) {
+      System.assertNotEquals(
+        null,
+        c.UnsubscribeLinkContact__c,
+        'Unsubscribe link should not be null after batch execution.'
+      );
     }
+  }
+
+  @isTest
+  static void testUnsubscribeLinkGenerationLead() {
+    // Arrange: Run the batch job and check unsubscribe link generation
+    UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
+    Test.startTest();
+    Database.executeBatch(batchJob, 200);
+    Test.stopTest();
+
+    // Assert: Verify unsubscribe links are generated for all contacts
+    List<Lead> leadsAfter = [
+      SELECT Id, Public_Id__c, UnsubscribeLinkLead__c
+      FROM Lead
+      WHERE Public_Id__c != NULL
+    ];
+    for (Lead l : leadsAfter) {
+      System.assertNotEquals(
+        null,
+        l.UnsubscribeLinkLead__c,
+        'Unsubscribe link should not be null after batch execution.'
+      );
+    }
+  }
 }

--- a/force-app/main/default/classes/UUIDBatchJobTest.cls
+++ b/force-app/main/default/classes/UUIDBatchJobTest.cls
@@ -3,8 +3,6 @@ private class UUIDBatchJobTest {
 
     @TestSetup
     static void setupTestData() {
-        // TO DO: Add custom metadata type or setting to bypass flows that set the Public_Id__c field when running test.
-        
         // Arrange: Create test data for Contacts and Leads with null UUID fields
         List<Contact> contacts = new List<Contact>();
         List<Lead> leads = new List<Lead>();
@@ -15,7 +13,6 @@ private class UUIDBatchJobTest {
                 LastName = 'McTester ' + i,
                 Public_Id__c = null // Field to hold the UUID
             ));
-
             leads.add(new Lead(
                 FirstName = 'Test',
                 LastName = 'McLeader ' + i,
@@ -38,16 +35,16 @@ private class UUIDBatchJobTest {
         // Act: Run the batch job for Contacts
         UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
         Test.startTest();
-        Database.executeBatch(batchJob, 200); // Set batch size to avoid multiple executions
+        Database.executeBatch(batchJob, 200); // Simulate multiple batches
         Test.stopTest();
 
         // Assert: Check that all Contacts now have a generated UUID
-        List<Contact> contactsAfter = [SELECT Id, Public_Id__c FROM Contact WHERE Public_Id__c != null];
+        List<Contact> contactsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkContact__c FROM Contact WHERE Public_Id__c != null];
         System.assertEquals(200, contactsAfter.size(), 'All contacts should have a generated UUID after the batch job.');
-
         for (Contact c : contactsAfter) {
             System.assertNotEquals(null, c.Public_Id__c, 'Public_Id__c should not be null after the batch job.');
             System.assertEquals(36, c.Public_Id__c.length(), 'Public_Id__c should be a valid UUID of 36 characters.');
+            System.assertNotEquals(null, c.UnsubscribeLinkContact__c, 'Unsubscribe link should be generated.');
         }
     }
 
@@ -60,16 +57,45 @@ private class UUIDBatchJobTest {
         // Act: Run the batch job for Leads
         UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
         Test.startTest();
-        Database.executeBatch(batchJob, 200); // Set batch size to avoid multiple executions
+        Database.executeBatch(batchJob, 200);
         Test.stopTest();
 
         // Assert: Check that all Leads now have a generated UUID
-        List<Lead> leadsAfter = [SELECT Id, Public_Id__c FROM Lead WHERE Public_Id__c != null];
+        List<Lead> leadsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkLead__c FROM Lead WHERE Public_Id__c != null];
         System.assertEquals(200, leadsAfter.size(), 'All leads should have a generated UUID after the batch job.');
-
         for (Lead l : leadsAfter) {
             System.assertNotEquals(null, l.Public_Id__c, 'Public_Id__c should not be null after the batch job.');
             System.assertEquals(36, l.Public_Id__c.length(), 'Public_Id__c should be a valid UUID of 36 characters.');
+            System.assertNotEquals(null, l.UnsubscribeLinkLead__c, 'Unsubscribe link should be generated.');
+        }
+    }
+
+    // Test the error handling when an invalid object type is passed
+    @isTest
+    static void testInvalidObjectType() {
+        Test.startTest();
+        try {
+            UUIDBatchJob invalidBatchJob = new UUIDBatchJob('InvalidObject', 'Public_Id__c');
+            Database.executeBatch(invalidBatchJob, 200);
+            System.assert(false, 'An exception should have been thrown for invalid object type.');
+        } catch (UUIDBatchJob.UUIDBatchException e) {
+            System.assertEquals('Object type must be Contact or Lead', e.getMessage());
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testUnsubscribeLinkGeneration() {
+        // Arrange: Run the batch job and check unsubscribe link generation
+        UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
+        Test.startTest();
+        Database.executeBatch(batchJob, 200);
+        Test.stopTest();
+
+        // Assert: Verify unsubscribe links are generated for all contacts
+        List<Contact> contactsAfter = [SELECT Id, Public_Id__c, UnsubscribeLinkContact__c FROM Contact WHERE Public_Id__c != null];
+        for (Contact c : contactsAfter) {
+            System.assertNotEquals(null, c.UnsubscribeLinkContact__c, 'Unsubscribe link should not be null after batch execution.');
         }
     }
 }

--- a/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
@@ -16,6 +16,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Contact.UnsubscribeLinkContact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Contact.Unsubscribe_Link_Contact__c</field>
         <readable>true</readable>
@@ -28,6 +33,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Lead.Public_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Lead.UnsubscribeLinkLead__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -146,6 +156,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Contact</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Lead</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>


### PR DESCRIPTION


# Critical Changes

Updated UUIDBatchJob to add additional logic to populate UnsubscribeLinkContact__c and/or UnsubscribeLinkLeads__c field(s). Includes logic to generate a Experience Site url/link. Requires that Experience Site ALWAYS be named "Unsubscribe"

# Changes

Additionally, added email notification when batch completes.

TO DO: Flows still appear to need to be updated to use the new UnsubscribeLinkContact__c or UnsubscribeLinkLead__c field(s)

# Issues Closed

N/A