### PR TITLE
Many Fixes

### DIFF
--- a/force-app/main/default/classes/UUIDBatchJobTest.cls
+++ b/force-app/main/default/classes/UUIDBatchJobTest.cls
@@ -44,7 +44,11 @@ private class UUIDBatchJobTest {
     );
 
     // Act: Run the batch job for Contacts
-    UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
+    UUIDBatchJob batchJob = new UUIDBatchJob(
+      'Contact',
+      'Public_Id__c',
+      'Unsubscribe all'
+    );
     Test.startTest();
     Database.executeBatch(batchJob, 200);
     Test.stopTest();
@@ -95,7 +99,11 @@ private class UUIDBatchJobTest {
     );
 
     // Act: Run the batch job for Leads
-    UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
+    UUIDBatchJob batchJob = new UUIDBatchJob(
+      'Lead',
+      'Public_Id__c',
+      'Unsubscribe all'
+    );
     Test.startTest();
     Database.executeBatch(batchJob, 200);
     Test.stopTest();
@@ -137,7 +145,8 @@ private class UUIDBatchJobTest {
     try {
       UUIDBatchJob invalidBatchJob = new UUIDBatchJob(
         'InvalidObject',
-        'Public_Id__c'
+        'Public_Id__c',
+        'Unsubscribe all'
       );
       Database.executeBatch(invalidBatchJob, 200);
       System.assert(
@@ -156,7 +165,11 @@ private class UUIDBatchJobTest {
   @isTest
   static void testUnsubscribeLinkGeneration() {
     // Arrange: Run the batch job and check unsubscribe link generation
-    UUIDBatchJob batchJob = new UUIDBatchJob('Contact', 'Public_Id__c');
+    UUIDBatchJob batchJob = new UUIDBatchJob(
+      'Contact',
+      'Public_Id__c',
+      'Unsubscribe all'
+    );
     Test.startTest();
     Database.executeBatch(batchJob, 200);
     Test.stopTest();
@@ -179,7 +192,11 @@ private class UUIDBatchJobTest {
   @isTest
   static void testUnsubscribeLinkGenerationLead() {
     // Arrange: Run the batch job and check unsubscribe link generation
-    UUIDBatchJob batchJob = new UUIDBatchJob('Lead', 'Public_Id__c');
+    UUIDBatchJob batchJob = new UUIDBatchJob(
+      'Lead',
+      'Public_Id__c',
+      'Unsubscribe all'
+    );
     Test.startTest();
     Database.executeBatch(batchJob, 200);
     Test.stopTest();

--- a/force-app/main/default/flows/Unsubscribe_Link_Quick.flow-meta.xml
+++ b/force-app/main/default/flows/Unsubscribe_Link_Quick.flow-meta.xml
@@ -362,7 +362,7 @@ If not, check if the custom metadata type allows the user to type in their email
         <description>confirmation screen for person to confirm they want to unsubscribe. Update &quot;our organization&quot; in the custom metadata type &quot;Unsubscribe Link.&quot;</description>
         <name>Are_you_sure</name>
         <label>Are you sure</label>
-        <locationX>852</locationX>
+        <locationX>853</locationX>
         <locationY>1373</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
@@ -372,7 +372,7 @@ If not, check if the custom metadata type allows the user to type in their email
         </connector>
         <fields>
             <name>Screen1</name>
-            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px; color: rgb(0, 0, 0);&quot;&gt;{!Get_Unsubscribe_Link_Setup.Screen_1_Part_1__c} {!Email} {&lt;/span&gt;&lt;span style=&quot;font-size: 18px; color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);&quot;&gt;!Get_Unsubscribe_Link_Setup&lt;/span&gt;&lt;span style=&quot;font-size: 18px; color: rgb(0, 0, 0);&quot;&gt;.UnsubscribeLnk__Screen_1_Part_2__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;&lt;span style=&quot;color: rgb(0, 0, 0); font-size: 18px;&quot;&gt;{!Get_Unsubscribe_Link_Setup.Screen_1_Part_1__c} {!Email} {!Get_Unsubscribe_Link_Setup.Screen_1_Part_2__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -381,14 +381,14 @@ If not, check if the custom metadata type allows the user to type in their email
     <screens>
         <name>screenConfirmationEmail</name>
         <label>screenConfirmationEmail</label>
-        <locationX>954</locationX>
+        <locationX>955</locationX>
         <locationY>1802</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
         <fields>
             <name>confirmationScreen</name>
-            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;{!&lt;/span&gt;&lt;span style=&quot;font-size: 18px; background-color: rgb(255, 255, 255); color: rgb(0, 0, 0);&quot;&gt;!Get_Unsubscribe_Link_Setup&lt;/span&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;.UnsubscribeLnk__Screen_2_Part_1__c} {!&lt;/span&gt;&lt;span style=&quot;font-size: 18px; background-color: rgb(255, 255, 255); color: rgb(0, 0, 0);&quot;&gt;!Get_Unsubscribe_Link_Setup&lt;/span&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;.UnsubscribeLnk__Screen_2_Part_2__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;{!Get_Unsubscribe_Link_Setup.Screen_2_Part_1__c} {!Get_Unsubscribe_Link_Setup.Screen_2_Part_2__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>false</showFooter>
@@ -397,14 +397,14 @@ If not, check if the custom metadata type allows the user to type in their email
     <screens>
         <name>screenConfirmationNoEmail</name>
         <label>screenConfirmationNoEmail</label>
-        <locationX>1443</locationX>
+        <locationX>1444</locationX>
         <locationY>1703</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
         <fields>
             <name>confirmationScreenNoEmail</name>
-            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px; background-color: rgb(255, 255, 255); color: rgb(0, 0, 0);&quot;&gt;{!Get_Unsubscribe_Link_Setup&lt;/span&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;UnsubscribeLnk__Screen_2_Part_1__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;{!Get_Unsubscribe_Link_Setup.Screen_2_Part_1__c}&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>false</showFooter>

--- a/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
+++ b/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
@@ -8,7 +8,7 @@
         <actionName>UUIDBatchInvocable</actionName>
         <actionType>apex</actionType>
         <connector>
-            <targetReference>completeScreen</targetReference>
+            <targetReference>LeadBatch</targetReference>
         </connector>
         <flowTransactionModel>Automatic</flowTransactionModel>
         <inputParameters>
@@ -27,6 +27,38 @@
             <name>objectType</name>
             <value>
                 <stringValue>Contact</stringValue>
+            </value>
+        </inputParameters>
+        <nameSegment>UUIDBatchInvocable</nameSegment>
+        <versionSegment>1</versionSegment>
+    </actionCalls>
+    <actionCalls>
+        <name>LeadBatch</name>
+        <label>Lead Batch</label>
+        <locationX>1845</locationX>
+        <locationY>2341</locationY>
+        <actionName>UUIDBatchInvocable</actionName>
+        <actionType>apex</actionType>
+        <connector>
+            <targetReference>completeScreen</targetReference>
+        </connector>
+        <flowTransactionModel>Automatic</flowTransactionModel>
+        <inputParameters>
+            <name>fieldName</name>
+            <value>
+                <stringValue>Public_Id__c</stringValue>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>linkText</name>
+            <value>
+                <elementReference>LinkText</elementReference>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>objectType</name>
+            <value>
+                <stringValue>Lead</stringValue>
             </value>
         </inputParameters>
         <nameSegment>UUIDBatchInvocable</nameSegment>
@@ -103,7 +135,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Create_Record</targetReference>
+            <targetReference>ExistingRecordSameName_0_0</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -400,6 +432,32 @@
         </rules>
     </decisions>
     <decisions>
+        <description>Does a setup record exist already</description>
+        <name>ExistingRecordSameName_0_0</name>
+        <label>Setup Record Exists?</label>
+        <locationX>1395</locationX>
+        <locationY>1898</locationY>
+        <defaultConnector>
+            <targetReference>Create_Record</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No record</defaultConnectorLabel>
+        <rules>
+            <name>RecordExists_0</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>getULSetup</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Update_existing_record</targetReference>
+            </connector>
+            <label>Record exists</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>IncludeScreen3Decision</name>
         <label>Include Email Type In Screen</label>
         <locationX>1703</locationX>
@@ -424,7 +482,7 @@
             <label>Include Confirmation Screen</label>
         </rules>
     </decisions>
-    <description>New contact batch to pass in the link text. Make sure the create records looks for duplicates!</description>
+    <description>New contact batch to pass in the link text. This version has an extra decision to check if record needs to be created or updated.</description>
     <dynamicChoiceSets>
         <name>orgWideEmails</name>
         <dataType>String</dataType>
@@ -558,6 +616,16 @@
         <object>Unsubscribe_Link_Setup__c</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
+    <recordUpdates>
+        <name>Update_existing_record</name>
+        <label>Update existing record</label>
+        <locationX>1281</locationX>
+        <locationY>2031</locationY>
+        <connector>
+            <targetReference>Create_Public_Ids</targetReference>
+        </connector>
+        <inputReference>var_FinalRecord</inputReference>
+    </recordUpdates>
     <screens>
         <name>CompanyName</name>
         <label>CompanyName</label>
@@ -615,8 +683,8 @@
     <screens>
         <name>completeScreen</name>
         <label>completeScreen</label>
-        <locationX>1703</locationX>
-        <locationY>2402</locationY>
+        <locationX>1700</locationX>
+        <locationY>2441</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
@@ -1209,7 +1277,7 @@
             <targetReference>getULSetup</targetReference>
         </connector>
     </start>
-    <status>Active</status>
+    <status>Draft</status>
     <textTemplates>
         <name>horizontalLine1</name>
         <isViewedAsPlainText>true</isViewedAsPlainText>

--- a/force-app/main/default/flows/recordIdBlankFlow.flow-meta.xml
+++ b/force-app/main/default/flows/recordIdBlankFlow.flow-meta.xml
@@ -170,7 +170,7 @@ This screen will appear if a matching record is not found in the database.</desc
         </connector>
         <fields>
             <name>confirmation_0</name>
-            <fieldText>&lt;p&gt;&lt;span style=&quot;font-size: 18px; font-family: verdana; color: rgb(0, 0, 0);&quot;&gt;{!Screen3}&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;&lt;span style=&quot;font-family: verdana; font-size: 18px;&quot;&gt;{!Screen3}&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>


### PR DESCRIPTION
Flow fixes so that custom object Unsubscribe Link Setups works completely!!
Weird changes in Unsubscribe Quick Flow. I needed to merge in field names again into screens to fix error in them not showing up. I do not think that permission sets or sharing rules or anything fixed it, but I could be wrong.


# Critical Changes

# Changes

# Issues Closed
#67 
#69  
