### PR TITLE
Removed some error handling

### DIFF
--- a/force-app/main/default/flows/Unsubscribe_Link_Quick.flow-meta.xml
+++ b/force-app/main/default/flows/Unsubscribe_Link_Quick.flow-meta.xml
@@ -54,69 +54,13 @@
         <nameSegment>emailSimple</nameSegment>
         <versionSegment>1</versionSegment>
     </actionCalls>
-    <actionCalls>
-        <name>Send_Error_Email</name>
-        <label>Send Error Email</label>
-        <locationX>731</locationX>
-        <locationY>919</locationY>
-        <actionName>emailSimple</actionName>
-        <actionType>emailSimple</actionType>
-        <connector>
-            <targetReference>Error_Alert_Email</targetReference>
-        </connector>
-        <flowTransactionModel>CurrentTransaction</flowTransactionModel>
-        <inputParameters>
-            <name>emailAddresses</name>
-            <value>
-                <elementReference>Get_Org_Wide_Email.Address</elementReference>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>senderType</name>
-            <value>
-                <stringValue>OrgWideEmailAddress</stringValue>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>senderAddress</name>
-            <value>
-                <elementReference>Get_Org_Wide_Email.Address</elementReference>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>emailSubject</name>
-            <value>
-                <stringValue>Error with Unsubscribe Link</stringValue>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>emailBody</name>
-            <value>
-                <elementReference>errorBody</elementReference>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>sendRichBody</name>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputParameters>
-        <inputParameters>
-            <name>useLineBreaks</name>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputParameters>
-        <nameSegment>emailSimple</nameSegment>
-        <versionSegment>1</versionSegment>
-    </actionCalls>
     <apiVersion>49.0</apiVersion>
     <decisions>
         <description>Was the original email with an unsubscribe link sent to a contact or a lead record? The Unsubscribe Link contains the public id., starting with C or L if it is a lead or contact. We need to find whether it is a contact or lead so that the Unsubscribe Record can be properly linked to the record.</description>
         <name>Contact_or_Lead</name>
         <label>Contact or Lead</label>
-        <locationX>1356</locationX>
-        <locationY>372</locationY>
+        <locationX>1287</locationX>
+        <locationY>362</locationY>
         <defaultConnector>
             <targetReference>Blank_Values_Flow</targetReference>
         </defaultConnector>
@@ -150,32 +94,6 @@
                 <targetReference>Get_Lead</targetReference>
             </connector>
             <label>Lead</label>
-        </rules>
-    </decisions>
-    <decisions>
-        <description>Can we find the unsubscribe setup object?</description>
-        <name>dec_Setup_object_found</name>
-        <label>Setup object found</label>
-        <locationX>998</locationX>
-        <locationY>358</locationY>
-        <defaultConnector>
-            <targetReference>Contact_or_Lead</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>UL Setup Found</defaultConnectorLabel>
-        <rules>
-            <name>Setup_not_found</name>
-            <conditionLogic>and</conditionLogic>
-            <conditions>
-                <leftValueReference>Get_Unsubscribe_Link_Setup</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>true</booleanValue>
-                </rightValue>
-            </conditions>
-            <connector>
-                <targetReference>Get_Org_Wide_Email</targetReference>
-            </connector>
-            <label>Setup not found</label>
         </rules>
     </decisions>
     <decisions>
@@ -268,7 +186,7 @@ If not, check if the custom metadata type allows the user to type in their email
             <label>No record found. Allow Type-In</label>
         </rules>
     </decisions>
-    <description>Added in some error handling including getting an org wide email address.</description>
+    <description>Customer facing flow of the Unsubscribe Link managed package from AppExchange.</description>
     <environments>Default</environments>
     <formulas>
         <description>get the total number of records that had this email address and unsubscribed.</description>
@@ -354,8 +272,8 @@ If not, check if the custom metadata type allows the user to type in their email
         <description>Look for a contact record with ID passed into the flow. Assign the email address to an email variable and the ID to a text variable called FoundId that is passed to other flows.</description>
         <name>Get_Contact</name>
         <label>Get Contact</label>
-        <locationX>822</locationX>
-        <locationY>506</locationY>
+        <locationX>1001</locationX>
+        <locationY>583</locationY>
         <assignNullValuesIfNoRecordsFound>true</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Was_a_Record_Found</targetReference>
@@ -392,8 +310,8 @@ If not, check if the custom metadata type allows the user to type in their email
         <description>Look for a lead record with ID passed into the flow. Assign the email address to an email variable and the ID to a text variable called FoundId that is passed to other flows.</description>
         <name>Get_Lead</name>
         <label>Get Lead</label>
-        <locationX>1350</locationX>
-        <locationY>506</locationY>
+        <locationX>1377</locationX>
+        <locationY>554</locationY>
         <assignNullValuesIfNoRecordsFound>true</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Was_a_Record_Found</targetReference>
@@ -420,37 +338,16 @@ If not, check if the custom metadata type allows the user to type in their email
         </outputAssignments>
     </recordLookups>
     <recordLookups>
-        <name>Get_Org_Wide_Email</name>
-        <label>Get Org Wide Email</label>
-        <locationX>690</locationX>
-        <locationY>594</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
-        <connector>
-            <targetReference>Send_Error_Email</targetReference>
-        </connector>
-        <filterLogic>and</filterLogic>
-        <filters>
-            <field>DisplayName</field>
-            <operator>EqualTo</operator>
-            <value>
-                <stringValue>Unsubscribe Error Handling</stringValue>
-            </value>
-        </filters>
-        <getFirstRecordOnly>true</getFirstRecordOnly>
-        <object>OrgWideEmailAddress</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordLookups>
-    <recordLookups>
         <name>Get_Unsubscribe_Link_Setup</name>
         <label>Get Unsubscribe Link Setup</label>
         <locationX>888</locationX>
         <locationY>185</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>dec_Setup_object_found</targetReference>
+            <targetReference>Contact_or_Lead</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Get_Org_Wide_Email</targetReference>
+            <targetReference>Error_Alert_Email</targetReference>
         </faultConnector>
         <getFirstRecordOnly>true</getFirstRecordOnly>
         <object>Unsubscribe_Link_Setup__c</object>
@@ -481,8 +378,8 @@ If not, check if the custom metadata type allows the user to type in their email
         <description>We will be alerted about an error at this point.</description>
         <name>Error_Alert_Email</name>
         <label>Error Alert Screen</label>
-        <locationX>1736</locationX>
-        <locationY>1224</locationY>
+        <locationX>1715</locationX>
+        <locationY>186</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>

--- a/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
+++ b/force-app/main/default/flows/Unsubscribe_Link_Setup.flow-meta.xml
@@ -85,7 +85,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Get_Org_Wide_Email_Address</targetReference>
+            <targetReference>UpdateFinalValues</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -108,7 +108,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Get_Org_Wide_Email_Address</targetReference>
+            <targetReference>UpdateFinalValues</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -390,8 +390,8 @@
         <description>Assign values to the final variable based on answers to the initial screen.</description>
         <name>UpdateFinalValues</name>
         <label>UpdateFinalValues</label>
-        <locationX>577</locationX>
-        <locationY>2054</locationY>
+        <locationX>578</locationX>
+        <locationY>1373</locationY>
         <assignmentItems>
             <assignToReference>var_FinalRecord.Confirmation_Email_Text__c</assignToReference>
             <operator>Assign</operator>
@@ -609,32 +609,6 @@
             <label>Include Confirmation Screen</label>
         </rules>
     </decisions>
-    <decisions>
-        <description>Does an org wide email address already exist for error handling?</description>
-        <name>Is_there_already_an_org_wide_email_address</name>
-        <label>Error handling email exists</label>
-        <locationX>577</locationX>
-        <locationY>1538</locationY>
-        <defaultConnector>
-            <targetReference>Create_Org_Wide_Email_Address</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>No</defaultConnectorLabel>
-        <rules>
-            <name>YesAlreadyOrgWideEmail</name>
-            <conditionLogic>and</conditionLogic>
-            <conditions>
-                <leftValueReference>Get_Org_Wide_Email_Address</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
-                </rightValue>
-            </conditions>
-            <connector>
-                <targetReference>UpdateFinalValues</targetReference>
-            </connector>
-            <label>Yes</label>
-        </rules>
-    </decisions>
     <description>Included creating an org wide email address for confirmation email sender. And profile security.</description>
     <dynamicChoiceSets>
         <description>Pick another org wide email to get an error message.</description>
@@ -766,42 +740,6 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>
-        <description>Create the email address to handle errors at the beginning of the Unsubscribe Quick Flow.</description>
-        <name>Create_Org_Wide_error_Email</name>
-        <label>Org Wide Error Handling Email</label>
-        <locationX>687</locationX>
-        <locationY>1806</locationY>
-        <connector>
-            <targetReference>UpdateFinalValues</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Address</field>
-            <value>
-                <elementReference>ErrorEmailOrgWide.value</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>DisplayName</field>
-            <value>
-                <stringValue>Unsubscribe Error Handling</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>IsAllowAllProfiles</field>
-            <value>
-                <booleanValue>true</booleanValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Purpose</field>
-            <value>
-                <stringValue>UserSelection</stringValue>
-            </value>
-        </inputAssignments>
-        <object>OrgWideEmailAddress</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
         <description>Create the UL record.</description>
         <name>Create_Record</name>
         <label>Create Record</label>
@@ -846,34 +784,6 @@
         </filters>
         <getFirstRecordOnly>true</getFirstRecordOnly>
         <object>DomainSite</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordLookups>
-    <recordLookups>
-        <name>Get_Org_Wide_Email_Address</name>
-        <label>Get Org Wide Error Handling Email</label>
-        <locationX>582</locationX>
-        <locationY>1389</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
-        <connector>
-            <targetReference>Is_there_already_an_org_wide_email_address</targetReference>
-        </connector>
-        <filterLogic>and</filterLogic>
-        <filters>
-            <field>DisplayName</field>
-            <operator>EqualTo</operator>
-            <value>
-                <stringValue>Unsubscribe Error Handling</stringValue>
-            </value>
-        </filters>
-        <filters>
-            <field>Purpose</field>
-            <operator>EqualTo</operator>
-            <value>
-                <stringValue>UserSelection</stringValue>
-            </value>
-        </filters>
-        <getFirstRecordOnly>true</getFirstRecordOnly>
-        <object>OrgWideEmailAddress</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
     <recordLookups>
@@ -989,46 +899,6 @@
         <showHeader>false</showHeader>
     </screens>
     <screens>
-        <description>Create error handling email address</description>
-        <name>Create_Org_Wide_Email_Address</name>
-        <label>Create Error Org Wide Email Address</label>
-        <locationX>665</locationX>
-        <locationY>1646</locationY>
-        <allowBack>false</allowBack>
-        <allowFinish>true</allowFinish>
-        <allowPause>false</allowPause>
-        <connector>
-            <targetReference>Create_Org_Wide_error_Email</targetReference>
-        </connector>
-        <fields>
-            <name>ErrorEmailScreen</name>
-            <fieldText>&lt;p&gt;&lt;strong&gt;&lt;u&gt;Error handling&lt;/u&gt;&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Most errors in the Unsubscribe Link process will send standard flow error emails.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;However, if there is an error with the Unsubscribe Link Setup object, we need a specific organization-wide email address to be alerted when someone tries to unsubscribe.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;We will create one now. Look for the verification email.&lt;/p&gt;</fieldText>
-            <fieldType>DisplayText</fieldType>
-        </fields>
-        <fields>
-            <name>ErrorEmailOrgWide</name>
-            <extensionName>flowruntime:email</extensionName>
-            <fieldType>ComponentInstance</fieldType>
-            <inputParameters>
-                <name>required</name>
-                <value>
-                    <booleanValue>true</booleanValue>
-                </value>
-            </inputParameters>
-            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
-            <isRequired>true</isRequired>
-            <storeOutputAutomatically>true</storeOutputAutomatically>
-        </fields>
-        <fields>
-            <name>dis_ReadyToPreview</name>
-            <fieldText>&lt;p&gt;&lt;span style=&quot;background-color: rgb(255, 255, 255); font-size: 18px;&quot;&gt;{!horizontalLine1}&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt;Click &lt;/span&gt;&lt;em style=&quot;font-size: 18px;&quot;&gt;Preview&lt;/em&gt;&lt;span style=&quot;font-size: 18px;&quot;&gt; to see the unsubscribe process from the email recipient&apos;s perspective.&lt;/span&gt;&lt;/p&gt;</fieldText>
-            <fieldType>DisplayText</fieldType>
-        </fields>
-        <nextOrFinishButtonLabel>Preview</nextOrFinishButtonLabel>
-        <showFooter>true</showFooter>
-        <showHeader>false</showHeader>
-    </screens>
-    <screens>
         <name>Create_Public_Ids</name>
         <label>Create Public Ids</label>
         <locationX>577</locationX>
@@ -1051,8 +921,8 @@
         <description>A preview of the email with the option to modify the text of the link</description>
         <name>EmailModifyScreen</name>
         <label>Screen Email Preview</label>
-        <locationX>577</locationX>
-        <locationY>2162</locationY>
+        <locationX>578</locationX>
+        <locationY>1565</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>


### PR DESCRIPTION
I had added too much error handling, and I walked it back. If the Unsubscribe Link Setup object is not setup, then the email recipient will get a bad link, and that is okay.



# Critical Changes

# Changes

# Issues Closed
