### PR TITLE
feature/Update object permissions to allow edit for Lead and Contact

### DIFF
--- a/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
@@ -148,7 +148,7 @@
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>
-        <allowEdit>false</allowEdit>
+        <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Contact</object>
@@ -157,7 +157,7 @@
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>
-        <allowEdit>false</allowEdit>
+        <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Lead</object>

--- a/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Unsubscribe_Link.permissionset-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Needed for Unsubscribe Link package</description>
+    <description>Needed for Unsubscribe Link package.</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>Contact.HasOptedOutOfEmail</field>


### PR DESCRIPTION
This is a fresh PR attempt after renaming the previous branch from bugfix/permission-set to feature/permission-set

# Critical Changes

# Changes
Updated permissionset-meta to add edit access to Contact and Lead objects. This allows the field level permissions to populate.

# Issues Closed
#126  - email opt out fields not in permission set