### PR TITLE
Enable CI workflow on all pull requests

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -1,8 +1,6 @@
 name: "Feature Test"
 on:
-  push:
-    branches:
-      - feature/**
+  pull_request:
 
 
 jobs:


### PR DESCRIPTION
## Summary
Updates the feature test workflow to run on all pull requests instead of only pushes to `feature/**` branches.

## Changes
- Replaces `push` trigger with `pull_request` trigger
- Workflow now runs on PRs from any branch to any branch
- Fork PRs will run after maintainer approval (per repository settings)